### PR TITLE
fix(graph): delete member with background context

### DIFF
--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -123,7 +123,7 @@ func (r *mutationResolver) DeleteMember(ctx context.Context, firebaseID string) 
 		return nil, err
 	}
 
-	err = member.Delete(ctx, r.Server, client, dbClient, firebaseID)
+	err = member.Delete(context.Background(), r.Server, client, dbClient, firebaseID)
 	if err != nil {
 		err = errors.WithMessagef(err, "Failed to delete Firebase User(%s)", firebaseID)
 		log.Error(err)

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -123,6 +123,7 @@ func (r *mutationResolver) DeleteMember(ctx context.Context, firebaseID string) 
 		return nil, err
 	}
 
+	// use context.Background() so that the "delete member" can finish without interuption
 	err = member.Delete(context.Background(), r.Server, client, dbClient, firebaseID)
 	if err != nil {
 		err = errors.WithMessagef(err, "Failed to delete Firebase User(%s)", firebaseID)


### PR DESCRIPTION
Because to delete member is so critical, it needs to finish without interruption.