### PR TITLE
[wip] add memberState to all successful reply message and truncate the content according to it

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -29,6 +29,9 @@ import (
 	"github.com/mirror-media/mm-apigateway/graph/generated"
 )
 
+// TODO remove me and use the state from Israfil only
+const MemberStateNone = "none"
+
 // GetIDTokenOnly is a middleware to construct the token.Token interface
 func GetIDTokenOnly(server *Server) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -241,8 +244,9 @@ func ModifyReverseProxyResponse(c *gin.Context, rdb Rediser, cacheTTL int) func(
 		}
 
 		b, err := json.Marshal(Reply{
-			TokenState: tokenState,
-			Data:       json.RawMessage(body),
+			TokenState:  tokenState,
+			MemberState: MemberStateNone,
+			Data:        json.RawMessage(body),
 		})
 
 		if err != nil {
@@ -314,8 +318,9 @@ func NewSingleHostReverseProxy(target *url.URL, pathBaseToStrip string, rdb Redi
 			}
 
 			c.AbortWithStatusJSON(http.StatusOK, Reply{
-				TokenState: tokenState,
-				Data:       json.RawMessage(body),
+				TokenState:  tokenState,
+				MemberState: MemberStateNone,
+				Data:        json.RawMessage(body),
 			})
 			return
 		}
@@ -327,8 +332,9 @@ func NewSingleHostReverseProxy(target *url.URL, pathBaseToStrip string, rdb Redi
 }
 
 type Reply struct {
-	TokenState interface{} `json:"tokenState"`
-	Data       interface{} `json:"data,omitempty"`
+	TokenState  interface{} `json:"tokenState"`
+	MemberState interface{} `json:"memberState"`
+	Data        interface{} `json:"data,omitempty"`
 }
 
 type Error struct {
@@ -370,7 +376,8 @@ func SetRoute(server *Server) error {
 			return
 		}
 		c.JSON(http.StatusOK, Reply{
-			TokenState: t.GetTokenState(),
+			TokenState:  t.GetTokenState(),
+			MemberState: MemberStateNone,
 		})
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

Feature enhancement and spec change.

**What this PR does / why we need it:**

To prepare for the upcoming of member subscription change, it will add `memberState` to the reply with its state in `Israfil` and truncate the content accordingly.

For now, only reply is changed without state query implementation. The PR is to review the interface change first.

**Special notes for your reviewer:**

Please review the the change of the interface.

**Does this PR introduce a user-facing change?**

Yes. `memberState` is added to the reply of a successful request.

Possible values are all strings:

1. none
2. marketing
3. subscriber

A successful reply may look like
```
{
  "tokenState": "ok",
  "memberState": "none",
  "data": {...}
}
```