### PR TITLE
Feat/truncate content depending on member

### DIFF
--- a/server/proxy.go
+++ b/server/proxy.go
@@ -156,7 +156,18 @@ func ModifyReverseProxyResponse(c *gin.Context, rdb cache.Rediser, cacheTTL int)
 								logger.Errorf("encounter error when truncating apiData:", err)
 								return err
 							}
+							body, err = sjson.SetBytes(body, fmt.Sprintf("_items.%d.isTruncated", i), true)
+							if err != nil {
+								logger.Errorf("encounter error setting isTruncated to true for _items.%d", i, err)
+								return err
+							}
 							break
+						} else {
+							body, err = sjson.SetBytes(body, fmt.Sprintf("_items.%d.isTruncated", i), false)
+							if err != nil {
+								logger.Errorf("encounter error setting isTruncated to false for _items.%d", i, err)
+								return err
+							}
 						}
 					}
 				}


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
/kind feature
/kind api-change

#### What this PR does / why we need it:

For `/v0/getposts` requests, `apigateway` proxy them to the content service and modified the response`

When user is not a memeber, the premium content are truncated.

In this PR, a property, `isTruncated` is added to the content to help client know the state of response.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:

Each post will have its own `isTruncated`property.

#### Does this PR introduce a user-facing change?
```release-note
`/v0/getposts` will have a new property `isTruncated` in each `_items` of the response.
```

#### Additional documentation e.g., usage docs, etc.:
```docs
NONE
```
