### PR TITLE
Fix/order number time zone

### DIFF
--- a/graph/member/mutationgraph/mutation.resolvers.go
+++ b/graph/member/mutationgraph/mutation.resolvers.go
@@ -6,6 +6,7 @@ package mutationgraph
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -169,11 +170,8 @@ func (r *mutationResolver) CreateSubscriptionRecurring(ctx context.Context, data
 		return nil, err
 	}
 
-	orderNumber, err := createOrderNumber(resp.SubscriptionInfo.ID)
-	if err != nil {
-		logrus.WithField("mutation", "createsubscription").Errorf("creating order number for subscription(%s) and member(%s)", resp.SubscriptionInfo.ID, firebaseID, err)
-		return nil, err
-	}
+	id, _ := strconv.ParseUint(resp.SubscriptionInfo.ID, 10, 64)
+	orderNumber := createOrderNumberByTaipeiTZ(time.Now(), id)
 
 	resp.SubscriptionInfo.OrderNumber = &orderNumber
 
@@ -300,12 +298,8 @@ func (r *mutationResolver) CreatesSubscriptionOneTime(ctx context.Context, data 
 		logrus.WithField("mutation", "createsubscription").Error(err)
 		return nil, err
 	}
-
-	orderNumber, err := createOrderNumber(resp.SubscriptionInfo.ID)
-	if err != nil {
-		logrus.WithField("mutation", "createsubscription").Errorf("creating order number for subscription(%s) and member(%s)", resp.SubscriptionInfo.ID, firebaseID, err)
-		return nil, err
-	}
+	id, _ := strconv.ParseUint(resp.SubscriptionInfo.ID, 10, 64)
+	orderNumber := createOrderNumberByTaipeiTZ(time.Now(), id)
 
 	resp.SubscriptionInfo.OrderNumber = &orderNumber
 

--- a/graph/member/mutationgraph/resolver.go
+++ b/graph/member/mutationgraph/resolver.go
@@ -229,7 +229,7 @@ func contain(ss []string, s string) bool {
 }
 
 func createOrderNumberByTaipeiTZ(t time.Time, id uint64) (orderNumber string) {
-	tz := time.FixedZone("Asia/Taipei", 8*3600)
+	tz, _ := time.LoadLocation("Asia/Taipei")
 	t = t.In(tz)
 	prefix := "M"
 

--- a/graph/member/mutationgraph/resolver.go
+++ b/graph/member/mutationgraph/resolver.go
@@ -228,15 +228,13 @@ func contain(ss []string, s string) bool {
 	return false
 }
 
-func createOrderNumber(id string) (orderNumber string, err error) {
-	t := time.Now()
+func createOrderNumberByTaipeiTZ(t time.Time, id uint64) (orderNumber string) {
+	tz := time.FixedZone("Asia/Taipei", 8*3600)
+	t = t.In(tz)
 	prefix := "M"
-	date := strconv.FormatInt(int64(t.Local().Year()), 10)[2:] + fmt.Sprintf("%02d", t.Local().Month()) + fmt.Sprintf("%02d", t.Local().Day())
 
-	n, err := strconv.ParseInt(id, 10, 64)
-	if err != nil {
-		return "", err
-	}
-	orderNumber = fmt.Sprintf("%s%s%05d", prefix, date, n%10000)
-	return orderNumber, nil
+	date := strconv.FormatInt(int64(t.Year()), 10)[2:] + fmt.Sprintf("%02d", t.Month()) + fmt.Sprintf("%02d", t.Day())
+
+	orderNumber = fmt.Sprintf("%s%s%05d", prefix, date, id%10000)
+	return orderNumber
 }

--- a/graph/member/mutationgraph/resolver_test.go
+++ b/graph/member/mutationgraph/resolver_test.go
@@ -42,6 +42,14 @@ func Test_createOrderNumberByTaipeiTZ(t *testing.T) {
 			},
 			wantOrderNumber: "M21110800001",
 		},
+		{
+			name: "10:00 at ast",
+			args: args{
+				t:  astAM10,
+				id: 100001,
+			},
+			wantOrderNumber: "M21110800001",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/graph/member/mutationgraph/resolver_test.go
+++ b/graph/member/mutationgraph/resolver_test.go
@@ -1,0 +1,54 @@
+package mutationgraph
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_createOrderNumberByTaipeiTZ(t *testing.T) {
+	utcPM10, _ := time.Parse(time.RFC3339, "2021-11-07T22:00:00+00:00")
+	utcAM10, _ := time.Parse(time.RFC3339, "2021-11-07T10:00:00+00:00")
+	astAM10, _ := time.Parse(time.RFC3339, "2021-11-07T10:00:00-09:00")
+	type args struct {
+		t  time.Time
+		id uint64
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantOrderNumber string
+	}{
+		{
+			name: "22:00 at utc",
+			args: args{
+				t:  utcPM10,
+				id: 1,
+			},
+			wantOrderNumber: "M21110800001",
+		},
+		{
+			name: "10:00 at utc",
+			args: args{
+				t:  utcAM10,
+				id: 1,
+			},
+			wantOrderNumber: "M21110700001",
+		},
+		{
+			name: "10:00 at ast",
+			args: args{
+				t:  astAM10,
+				id: 1,
+			},
+			wantOrderNumber: "M21110800001",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOrderNumber := createOrderNumberByTaipeiTZ(tt.args.t, tt.args.id)
+			if gotOrderNumber != tt.wantOrderNumber {
+				t.Errorf("createOrderNumberByTaipeiTZ() = %v, want %v", gotOrderNumber, tt.wantOrderNumber)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The order number of a subscription is a composite, `MyyMMDD00001`,  of current year, month, date and subscription ID. Like `M21110800001`.

API Gateway falsely use the timezone on the machine.

This PR use timezone in Asia/Taipei to generate order number.

## Note

Because the timezone in our machine is in UTC, merging the PR won't produce duplicated `orderNumber`.

Refers: https://app.asana.com/0/1201268625767017/1201328711013796/f